### PR TITLE
Add .hugo_build.lock file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .pydevproject
 .settings/
 local.mk
+.hugo_build.lock


### PR DESCRIPTION
New versions of hugo create this `hugo_build.lock` file which we can ignore from our git repo.

https://discourse.gohugo.io/t/what-is-the-hugo-build-lock-file/35417